### PR TITLE
bug fix(csvprovider): convert ProviderID to lowercase for pv

### DIFF
--- a/pkg/cloud/provider/csvprovider.go
+++ b/pkg/cloud/provider/csvprovider.go
@@ -423,7 +423,7 @@ func (c *CSVProvider) GetPVKey(pv *clustercache.PersistentVolume, parameters map
 	id := PVValueFromMapField(c.PVMapField, pv)
 	return &csvPVKey{
 		Labels:                 pv.Labels,
-		ProviderID:             id,
+		ProviderID:             strings.ToLower(id),
 		StorageClassName:       pv.Spec.StorageClassName,
 		StorageClassParameters: parameters,
 		Name:                   pv.Name,


### PR DESCRIPTION
## What does this PR change?
I have this example csv file opencost is using.

EndTimestamp,InstanceID,Region,AssetClass,InstanceIDField,InstanceType,MarketPriceHourly,Version
2024-01-01,standard_d4s_v4,,node,metadata.labels.node.kubernetes.io/instance-type,standard_d4s_v4,0.9999,
2024-01-01,1Gi,,pv,spec.capacity.storage,1Gi,0.011111,

Node matches successfully, but my pv doesn't.  .spec.capacity.storage values are for example:

kubectl get pv -A -o yaml | yq '.items[] | .spec.capacity.storage'
1Gi
16Gi

It seems there is a bug with the case matching of PVs. When the instance type is retrieved from the CSV it's [converted to lowercase](https://github.com/opencost/opencost/blob/develop/pkg/cloud/provider/csvprovider.go#L155).  However, the field retrieved from the [pv object is not.](https://github.com/opencost/opencost/blob/develop/pkg/cloud/provider/csvprovider.go#L426)  In comparison, the code for [node converts key to lowercase](https://github.com/opencost/opencost/blob/develop/pkg/cloud/provider/csvprovider.go#L394).


## How will this PR impact users?
Fixes bug for csvprovider pv objects.  InstanceIDField with uppercase letters will now properly match.

## Does this PR address any GitHub or Zendesk issues?
Haven't opened one.

## How was this PR tested?
Built image and used it in my deployment.  Opencost was using csv pricing for my PVs.

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
Can't add label